### PR TITLE
Added Remaining Show Help Descriptions

### DIFF
--- a/src/commands/dotnet/add/index.ts
+++ b/src/commands/dotnet/add/index.ts
@@ -17,7 +17,7 @@ export default class Add extends Command {
   static description = 'add a new module';
 
   static flags = {
-    help: Flags.boolean({ hidden: false }),
+    help: Flags.boolean({name:'help',description: 'Show help information ', hidden: false }),
   }
 
   static args = {

--- a/src/commands/dotnet/index.ts
+++ b/src/commands/dotnet/index.ts
@@ -16,7 +16,7 @@ export default class Dotnet extends Command {
   static description = 'Dotnet API scaffolding';
 
   static flags = {
-    help: Flags.boolean({ hidden: false }),
+    help: Flags.boolean({name:'help',description: 'Show help information ', hidden: false }),
     isTopic: Flags.string({ name: 'isTopic', hidden: true }),
   }
 

--- a/src/commands/dotnet/migrate/index.ts
+++ b/src/commands/dotnet/migrate/index.ts
@@ -8,7 +8,7 @@ export default class Migrate extends Command {
   static description = 'perform a migration action';
 
   static flags = {
-    help: Flags.boolean({ hidden: false }),
+    help: Flags.boolean({name:'help',description: 'Show help information ', hidden: false }),
   }
 
   static args = {

--- a/src/commands/mobile/add/index.ts
+++ b/src/commands/mobile/add/index.ts
@@ -7,7 +7,7 @@ export default class Add extends Command {
   static description = 'add a new module'
 
   static flags = {
-    help: Flags.boolean({ hidden: false }),
+    help: Flags.boolean({name:'help',description: 'Show help information ', hidden: false }),
   }
 
   static args = {

--- a/src/commands/vue/add/index.ts
+++ b/src/commands/vue/add/index.ts
@@ -17,7 +17,7 @@ export default class Add extends Command {
   static description = 'add a new module';
 
   static flags = {
-    help: Flags.boolean({ hidden: false }),
+    help: Flags.boolean({name:'help',description: 'Show help information ', hidden: false }),
   }
 
   static args = {

--- a/src/commands/vue/plugin/index.ts
+++ b/src/commands/vue/plugin/index.ts
@@ -8,7 +8,7 @@ export default class Plugin extends Command {
   static description = 'install a plugin'
 
   static flags = {
-    help: Flags.boolean({ hidden: false }),
+    help: Flags.boolean({name:'help',description: 'Show help information ', hidden: false }),
   }
 
   static args = {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
There were some missing show help descriptions for some of the help menus which caused an undefined description to be shown. That undefined description was replaced with "Show help information" description instead.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
